### PR TITLE
bump version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,20 @@ workflows:
           filters: # run for all branches AND tags
             tags:
               only: /.*/
+      - docker/publish:
+          requires:
+              - build-and-test
+              - integration-test
+          filters: # only run for semver tagged versions
+              tags:
+                  only: /^([0-9]+)\.([0-9]+)\.([0-9]+)/
+              branches:
+                  ignore: /.*/
+          update-description: true
+          docker-context: implementations/demo
+          dockerfile: implementations/demo/Dockerfile.production
+          image: kivaprotocol/demo-controller
+          tag: << pipeline.git.tag >>
 
 orbs:
   node: circleci/node@4.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1493,9 +1493,9 @@
             }
         },
         "aries-controller": {
-            "version": "1.0.13",
-            "resolved": "https://registry.npmjs.org/aries-controller/-/aries-controller-1.0.13.tgz",
-            "integrity": "sha512-wAsJWK0mN7Yn7KwN63O4sis0dx9hICzhl4FFf2Nc7cqhHW9m8qT2PmWJSS/FxsJ767H9sYo06gsp9E2iArJcxQ==",
+            "version": "1.0.14",
+            "resolved": "https://registry.npmjs.org/aries-controller/-/aries-controller-1.0.14.tgz",
+            "integrity": "sha512-9iSe168+lkDA5mf2sG0FjJRsuy5G+NDRw9eSB02ubAvAl2Vo1IUHnhZPZ/X0b8AqOPPAVutAZCISqWI5APM35A==",
             "requires": {
                 "@nestjs/common": "^7.5.5",
                 "@nestjs/core": "^7.5.5",
@@ -3629,9 +3629,9 @@
             "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
             "dev": true
         },
         "int64-buffer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1493,9 +1493,9 @@
             }
         },
         "aries-controller": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/aries-controller/-/aries-controller-1.0.10.tgz",
-            "integrity": "sha512-GF0OTXTRIavVwQMAQfPMHe2ZRm/VKQS0X8z07FMT7rRhpSrCKZ0V4rEZ6cOpci5aCSXKjuI1iou/dafW/FW8zA==",
+            "version": "1.0.13",
+            "resolved": "https://registry.npmjs.org/aries-controller/-/aries-controller-1.0.13.tgz",
+            "integrity": "sha512-wAsJWK0mN7Yn7KwN63O4sis0dx9hICzhl4FFf2Nc7cqhHW9m8qT2PmWJSS/FxsJ767H9sYo06gsp9E2iArJcxQ==",
             "requires": {
                 "@nestjs/common": "^7.5.5",
                 "@nestjs/core": "^7.5.5",
@@ -7668,9 +7668,9 @@
             }
         },
         "swagger-ui-dist": {
-            "version": "3.37.2",
-            "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.37.2.tgz",
-            "integrity": "sha512-XIT4asxgeL4GUNPPsqpEqLt20M/u6OhFYqTh42IoEAvAyv5e9EGw5uhP9dLAD10opcMYqdkJ5qU+MpN2HZ5xyA=="
+            "version": "3.38.0",
+            "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.38.0.tgz",
+            "integrity": "sha512-sselV8VY6f1BBauY9Sdmwz0jVaWTnGuHQWei7BaTpiUrLcoEUdmmK5bKefLXiwq+dx//es2S8mOvUS+tcXDsKg=="
         },
         "swagger-ui-express": {
             "version": "4.1.5",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "@nestjs/common": "~7.5.5",
         "@nestjs/core": "~7.5.5",
         "@nestjs/swagger": "^4.7.5",
-        "aries-controller": "^1.0.10",
+        "aries-controller": "1.0.13",
         "class-transformer": "^0.3.1",
         "dotenv": "^8.2.0",
         "protocol-common": "0.1.24"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "@nestjs/common": "~7.5.5",
         "@nestjs/core": "~7.5.5",
         "@nestjs/swagger": "^4.7.5",
-        "aries-controller": "1.0.13",
+        "aries-controller": "1.0.14",
         "class-transformer": "^0.3.1",
         "dotenv": "^8.2.0",
         "protocol-common": "0.1.24"


### PR DESCRIPTION
Adds demo controller building to ci, and bumps aries-controller version (plus security npm bumps)
Signed-off-by: Jacob Saur <jsaur@kiva.org>