### PR TITLE
Add identity cred def that's tied to the full kyc one

### DIFF
--- a/profiles/identity.cred.def.json
+++ b/profiles/identity.cred.def.json
@@ -1,0 +1,65 @@
+{
+    "DEFAULT": {
+        "schema_name": "Identity",
+        "comment": "National ID card",
+        "credential_proposal": {
+            "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/issue-credential/1.0/credential-preview"
+        },
+        "support_revocation": false,
+        "auto_remove": true,
+        "attributes": [
+            "nationalId",
+            "nationalIssueDate",
+            "voterId",
+            "voterIssueDate",
+            "firstName",
+            "middleName",
+            "lastName",
+            "gender",
+            "birthDate",
+            "birthPlace",
+            "residentialAddress",
+            "permanentAddress",
+            "phoneNumber",
+            "motherFirstName",
+            "motherLastName",
+            "fatherFirstName",
+            "fatherLastName",
+            "occupation",
+            "maritalStatus",
+            "photo~attach",
+            "signature~attach"
+        ]
+    },
+    "LOCAL": {
+        "issuer_did": "XTv4YCzYj8jqZgL1wVMGGL",
+        "tag": "tag",
+        "schema_issuer_did": "Th7MpTaRZVRYnPiabds81Y",
+        "schema_version": "1.0.0",
+        "schema_id": "Th7MpTaRZVRYnPiabds81Y:2:Identity:1.0.0"
+    },
+    "DEV": {
+        "issuer_did": "RcR5kSj5tuBM1q8kTiiZbd",
+        "tag": "tag2",
+        "schema_issuer_did": "McP1XxbNgbWL1ZNgQQB9YL",
+        "schema_version": "1.0.27",
+        "schema_id": "McP1XxbNgbWL1ZNgQQB9YL:2:Identity:1.0.27"
+    },
+    "QA": {
+        "issuer_did": "6Jsj4gmrYib3YDufowgx2N",
+        "tag": "tag2",
+        "schema_issuer_did": "McP1XxbNgbWL1ZNgQQB9YL",
+        "schema_version": "1.0.27",
+        "schema_id": "McP1XxbNgbWL1ZNgQQB9YL:2:Identity:1.0.27"
+    },
+    "SAND": {
+        "issuer_did": "d49msToBfLewc96BvTFfJ",
+        "tag": "tag2",
+        "schema_issuer_did": "3bymcHbJGvAG77FuAB3hZh",
+        "schema_version": "1.0.2",
+        "schema_id": "3bymcHbJGvAG77FuAB3hZh:2:Identity:1.0.2"
+    },
+    "PROD": {
+
+    }
+}


### PR DESCRIPTION
The cred defs that we've deployed on our remote envs have the full SL kyc attributes list, so this adds a profile so we can continue issuing credentials against that.
Bug details here: https://kiva.atlassian.net/browse/PRO-2894
Signed-off-by: Jacob Saur <jsaur@kiva.org>