### PR TITLE
fix simple stop script

### DIFF
--- a/scripts/simple_stop.sh
+++ b/scripts/simple_stop.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Run from protocol-demo
 # Stops all the containers
-set -ev
+set -v
 
 docker-compose -f docker-compose.yml down
 # Stop all running agents


### PR DESCRIPTION
Fixes https://github.com/kiva/protocol-demo/issues/55 error on simple stop script. Note it will still display an error message, which is fine, it then continues on it's way stopping all the containers.
Signed-off-by: Jacob Saur <jsaur@kiva.org>